### PR TITLE
Implement SMTP notifications for grade complaints

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation(libs.credentials.play.services.auth)
     implementation(libs.googleid)
     implementation(libs.firebase.firestore)
+    implementation(libs.android.mail)
+    implementation(libs.android.activation)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/java/com/example/bbuniversity/etudiant/StudentDashboard.java
+++ b/app/src/main/java/com/example/bbuniversity/etudiant/StudentDashboard.java
@@ -147,7 +147,7 @@ public class StudentDashboard extends AppCompatActivity {
                 .addOnSuccessListener(r -> Toast.makeText(this , "Plainte envoyee" , Toast.LENGTH_SHORT).show())
                 .addOnFailureListener(e -> Toast.makeText(this , "Erreur : " + e.getMessage() , Toast.LENGTH_SHORT).show());
 
-        notifyTeacher(note.getProfesseurId(), message);
+        notifyTeacher(note.getProfesseurId(), message); // send email to professor
     }
 
     private void notifyTeacher(String profId, String message) {
@@ -156,14 +156,17 @@ public class StudentDashboard extends AppCompatActivity {
                 .addOnSuccessListener(doc -> {
                     String email = doc.getString("email");
                     if (email != null) {
-                        android.content.Intent intent = new android.content.Intent(android.content.Intent.ACTION_SENDTO);
-                        intent.setData(android.net.Uri.parse("mailto:" + email));
-                        intent.putExtra(android.content.Intent.EXTRA_SUBJECT, "New grade complaint");
-                        intent.putExtra(android.content.Intent.EXTRA_TEXT, message);
-                        try {
-                            startActivity(intent);
-                        } catch (android.content.ActivityNotFoundException ignored) {
-                        }
+                        new Thread(() -> {
+                            try {
+                                com.example.bbuniversity.utils.EmailSender.sendEmail(
+                                        email,
+                                        "New grade complaint",
+                                        message
+                                );
+                            } catch (javax.mail.MessagingException e) {
+                                e.printStackTrace();
+                            }
+                        }).start();
                     }
                 });
     }

--- a/app/src/main/java/com/example/bbuniversity/etudiant/StudentGradesActivity.java
+++ b/app/src/main/java/com/example/bbuniversity/etudiant/StudentGradesActivity.java
@@ -113,14 +113,17 @@ public class StudentGradesActivity extends AppCompatActivity {
                 .addOnSuccessListener(doc -> {
                     String email = doc.getString("email");
                     if (email != null) {
-                        android.content.Intent intent = new android.content.Intent(android.content.Intent.ACTION_SENDTO);
-                        intent.setData(android.net.Uri.parse("mailto:" + email));
-                        intent.putExtra(android.content.Intent.EXTRA_SUBJECT, "New grade complaint");
-                        intent.putExtra(android.content.Intent.EXTRA_TEXT, message);
-                        try {
-                            startActivity(intent);
-                        } catch (android.content.ActivityNotFoundException ignored) {
-                        }
+                        new Thread(() -> {
+                            try {
+                                com.example.bbuniversity.utils.EmailSender.sendEmail(
+                                        email,
+                                        "New grade complaint",
+                                        message
+                                );
+                            } catch (javax.mail.MessagingException e) {
+                                e.printStackTrace();
+                            }
+                        }).start();
                     }
                 });
     }

--- a/app/src/main/java/com/example/bbuniversity/utils/EmailSender.java
+++ b/app/src/main/java/com/example/bbuniversity/utils/EmailSender.java
@@ -1,0 +1,46 @@
+package com.example.bbuniversity.utils;
+
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+/**
+ * Utility class to send emails using SMTP.
+ */
+public class EmailSender {
+
+    private static final String SMTP_HOST = "smtp.example.com"; // change to your SMTP host
+    private static final String SMTP_PORT = "587";              // change to your SMTP port
+    private static final String USERNAME = "username";          // SMTP account username
+    private static final String PASSWORD = "password";          // SMTP account password
+    private static final String FROM_EMAIL = "noreply@example.com"; // from address
+
+    public static void sendEmail(String to, String subject, String body) throws MessagingException {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", SMTP_HOST);
+        props.put("mail.smtp.port", SMTP_PORT);
+
+        Session session = Session.getInstance(props, new javax.mail.Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(USERNAME, PASSWORD);
+            }
+        });
+
+        Message message = new MimeMessage(session);
+        message.setFrom(new InternetAddress(FROM_EMAIL));
+        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
+        message.setSubject(subject);
+        message.setText(body);
+
+        Transport.send(message);
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ credentials = "1.5.0"
 credentialsPlayServicesAuth = "1.5.0"
 googleid = "1.1.1"
 firebaseFirestore = "25.1.4"
+javamail = "1.6.7"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -27,6 +28,8 @@ credentials = { group = "androidx.credentials", name = "credentials", version.re
 credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentialsPlayServicesAuth" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore", version.ref = "firebaseFirestore" }
+android-mail = { group = "com.sun.mail", name = "android-mail", version.ref = "javamail" }
+android-activation = { group = "com.sun.mail", name = "android-activation", version.ref = "javamail" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- notify professors about grade complaints via SMTP
- add `EmailSender` utility
- include JavaMail dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ad1f7bb708333978be44438469b3c